### PR TITLE
feat: 撤回+缓存

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ git clone https://github.com/Zhalslar/astrbot_plugin_box
 
 <img width="1102" height="417" alt="图片" src="https://github.com/user-attachments/assets/5174a076-b9c3-443a-9f77-4acea32268b3" />
 
+
 ## 👥 贡献指南
 
 - 🌟 Star 这个项目！（点右上角的星星，感谢支持！）

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -30,14 +30,20 @@
     "cookie": {
         "description": "Cookie",
         "type": "text",
-        "hint": "普通版此项为无效配置！用于pro版的高端局",
+        "hint": "高端局必填（Pro版专用，普通版无需配置）",
         "default": ""
     },
     "desensitize": {
         "description": "去敏化",
         "type": "bool",
-        "hint": "是否对敏感信息进行去敏化处理，包括：将手机号中间四位改为星号（普通版此项为无效配置）",
+        "hint": "是否对敏感信息进行去敏化处理，包括：将手机号中间四位改为星号（Pro版专用，普通版无需配置）",
         "default": true
+    },
+    "recall_time":{
+        "description": "撤回时间(秒)",
+        "type": "int",
+        "hint": "几秒后撤回开盒卡片，设为 0 则不撤回",
+        "default": 5
     },
     "display": {
         "description": "信息显示设置",

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,6 +2,6 @@ name: astrbot_plugin_box # 这是你的插件的唯一识别名。
 display_name: 开盒插件
 desc: 利用Onebot协议的接口获取QQ用户信息,并以图片形式展示  # 插件简短描述
 help: ...  # 插件的帮助信息
-version: v1.2.1 # 插件版本号。格式：v1.1.1 或者 v1.1
+version: v1.2.2 # 插件版本号。格式：v1.1.1 或者 v1.1
 author: Zhalslar # 作者
 repo: https://github.com/Zhalslar/astrbot_plugin_box # 插件的仓库地址

--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 from datetime import date
 
 import aiohttp
@@ -17,8 +19,7 @@ class WebUtils:
         self.session = aiohttp.ClientSession()
 
     async def search_library(self, target_id: str, cookie: str) -> dict | None:
-        """通过library获取数据"""
-        # 普通版BOX插件不可享用
+        """通过library获取数据(Pro版专用)"""
         pass
 
     async def get_avatar(self, user_id: str) -> bytes | None:
@@ -53,6 +54,18 @@ def get_ats(
     if block_ids:
         ats.difference_update(block_ids)
     return list(ats)
+
+
+def render_digest(stranger: dict, member: dict, avatar: bytes) -> str:
+    """计算哈希值：全字段(int/str)保留，头像单独md5"""
+    payload = {
+        "stranger": stranger,
+        "member": member,
+        "avatar": hashlib.md5(avatar).hexdigest(),
+    }
+    return hashlib.md5(
+        json.dumps(payload, sort_keys=True, ensure_ascii=False).encode()
+    ).hexdigest()
 
 
 def qqLevel_to_icon(level: int) -> str:


### PR DESCRIPTION
## Summary by Sourcery

为 Box 插件添加消息缓存和自动撤回支持，并相应更新元数据。

新功能：
- 引入基于摘要（digest）的图片缓存机制，用于缓存生成的 box 卡片，避免重复渲染。
- 添加可配置的 box 卡片消息自动撤回功能，可在指定延迟后撤回已发送消息。

改进：
- 优化 Box 插件中的头像获取回退处理逻辑以及消息流转控制。
- 在插件终止时跟踪并清理待处理的撤回任务，防止协程遗留。

文档：
- 以小幅布局调整的形式更新 README 的排版。

杂项：
- 在元数据中将插件版本提升至 v1.2.2。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add message caching and auto-recall support to the Box plugin, and update metadata accordingly.

New Features:
- Introduce a digest-based image caching mechanism for generated box cards to avoid redundant rendering.
- Add configurable auto-recall of sent box card messages after a specified delay.

Enhancements:
- Refine avatar retrieval fallback handling and messaging flow control in the Box plugin.
- Track and clean up pending recall tasks during plugin termination to prevent dangling coroutines.

Documentation:
- Update README formatting with a minor layout tweak.

Chores:
- Bump plugin version to v1.2.2 in metadata.

</details>